### PR TITLE
Add Maintenance and Calibration Requests

### DIFF
--- a/__tests__/app/dashboard/medical-equipment/[id]/calibration-request/page.unit.test.tsx
+++ b/__tests__/app/dashboard/medical-equipment/[id]/calibration-request/page.unit.test.tsx
@@ -1,10 +1,212 @@
-import { render, screen } from '@testing-library/react';
-import CalibrationRequestCreatePage from '@/app/dashboard/medical-equipment/[id]/calibration-request/page';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import CalibrationRequestCreate from '@/modules/medical-equipment/request/calibration/calibration-request-create';
+import { useRouter, useParams } from 'next/navigation';
+import Cookies from "js-cookie";
+import { decodeToken } from "@/lib/utils";
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+  useParams: jest.fn(),
+}));
+
+jest.mock("js-cookie", () => ({
+  get: jest.fn(),
+}));
+
+jest.mock("@/lib/utils", () => ({
+  ...jest.requireActual("@/lib/utils"),
+  decodeToken: jest.fn(),
+}));
 
 describe('CalibrationRequestCreatePage', () => {
-  it('', () => {
-    render(<CalibrationRequestCreatePage />);
-    const pageName = screen.getByText('CalibrationRequestCreate');
-    expect(pageName).toBeInTheDocument();
+  let mockPush: jest.Mock;
+  let mockBack: jest.Mock;
+  let mockUseParams: jest.Mock;
+
+  beforeEach(() => {
+    mockBack = jest.fn();
+    mockPush = jest.fn();
+    mockUseParams = jest.fn().mockReturnValue({ id: "1" });
+    (useRouter as jest.Mock).mockReturnValue({ push: mockPush, back: mockBack });
+    (useParams as jest.Mock).mockImplementation(mockUseParams);
+    (Cookies.get as jest.Mock).mockReturnValue("mock-token");
+    (decodeToken as jest.Mock).mockReturnValue({ userId: 'mock-user-id' });
+
+    global.fetch = jest.fn().mockImplementation((url) => {
+      if (url === `${process.env.NEXT_PUBLIC_API_URL}/calibration-request`) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({}),
+        });
+      } else if (url === `${process.env.NEXT_PUBLIC_API_URL}/medical-equipment/1`) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ data: { name: "mock-equipment-name" } }),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        json: () => Promise.resolve({}),
+      });
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the page correctly', async () => {
+    render(<CalibrationRequestCreate />);
+    
+    expect(screen.getByText('Kembali')).toBeInTheDocument();
+    expect(screen.getByText('Minta Calibration')).toBeInTheDocument();
+    expect(screen.getByLabelText(/Alat/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Catatan/i)).toBeInTheDocument();
+    expect(screen.getByText('Batalkan')).toBeInTheDocument();
+    expect(screen.getByText('Menyimpan...')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('Simpan')).toBeInTheDocument();
+    });
+  });
+
+  it('should go back when the kembali button is clicked', () => {
+    render(<CalibrationRequestCreate />);
+    
+    const backButton = screen.getByText('Kembali');
+    backButton.click();
+    
+    expect(mockBack).toHaveBeenCalled();
+  });
+
+  it('should go back when the batalkan button is clicked', () => {
+    render(<CalibrationRequestCreate />);
+    
+    const cancelButton = screen.getByText('Batalkan');
+    cancelButton.click();
+    
+    expect(mockBack).toHaveBeenCalled();
+  });
+  
+  it('should handle missing token', async () => {
+    (Cookies.get as jest.Mock).mockReturnValueOnce(null);
+    console.error = jest.fn();
+
+    render(<CalibrationRequestCreate />);
+
+    await waitFor(() => {
+      expect(console.error).toHaveBeenCalled();
+    });
+  });
+
+  it('should call the API to fetch medical equipment name', async () => {
+    render(<CalibrationRequestCreate />);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${process.env.NEXT_PUBLIC_API_URL}/medical-equipment/1`,
+        expect.objectContaining({
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': expect.stringContaining('Bearer'),
+          },
+        })
+      );
+    });
+  });
+  
+  it('should handle error when fetching medical equipment name fails', async () => {
+    global.fetch = jest.fn().mockImplementationOnce((url) => 
+      url === `${process.env.NEXT_PUBLIC_API_URL}/medical-equipment/1` 
+        ? Promise.resolve({
+            ok: false,
+            json: () => Promise.resolve({}),
+          })
+        : Promise.resolve()
+    );
+    console.error = jest.fn();
+
+    render(<CalibrationRequestCreate />);
+
+    await waitFor(() => {
+      expect(console.error).toHaveBeenCalledWith(
+        'Error fetching medical equipment name:', 
+        expect.any(Error));
+    });
+  });
+  
+  it('should open the error modal when there is an error and closed when get clicked', async () => {
+    global.fetch = jest.fn().mockImplementation((url) => {
+      if (url === `${process.env.NEXT_PUBLIC_API_URL}/calibration-request`) {
+        return Promise.resolve({
+          ok: false,
+          json: () => Promise.resolve({}),
+        });
+      } else if (url === `${process.env.NEXT_PUBLIC_API_URL}/medical-equipment/1`) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ data: { name: "mock-equipment-name" } }),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        json: () => Promise.resolve({}),
+      });
+    });
+
+    render(<CalibrationRequestCreate />);
+
+    await waitFor(() => {
+      fireEvent.change(screen.getByLabelText(/Catatan/i), {
+        target: { value: 'Test complaint' }
+      });
+      fireEvent.click(screen.getByText('Simpan'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Failed to create calibration request')).toHaveLength(2);
+    });
+
+    fireEvent.click(screen.getByText('Close'));
+
+    await waitFor(() => {
+      const errorTexts = screen.getAllByText('Failed to create calibration request');
+      expect(errorTexts).toHaveLength(1);
+    });
+  });
+  
+  it('should submit the form successfully', async () => {
+    render(<CalibrationRequestCreate />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Catatan/i)).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText(/Catatan/i), {
+      target: { value: 'Valid complaint' }
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Simpan')).toBeInTheDocument();
+    });
+    
+    fireEvent.click(screen.getByText('Simpan'));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${process.env.NEXT_PUBLIC_API_URL}/calibration-request`,
+        expect.objectContaining({
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': expect.stringContaining('Bearer'),
+          },
+          body: expect.any(String)
+        })
+      );
+      expect(mockPush).toHaveBeenCalledWith(
+        '/dashboard/medical-equipment/1?success=true'
+      );
+    });
   });
 });

--- a/__tests__/app/dashboard/medical-equipment/[id]/calibration-request/page.unit.test.tsx
+++ b/__tests__/app/dashboard/medical-equipment/[id]/calibration-request/page.unit.test.tsx
@@ -2,7 +2,6 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import CalibrationRequestCreate from '@/modules/medical-equipment/request/calibration/calibration-request-create';
 import { useRouter, useParams } from 'next/navigation';
 import Cookies from "js-cookie";
-import { decodeToken } from "@/lib/utils";
 
 jest.mock('next/navigation', () => ({
   useRouter: jest.fn(),
@@ -11,11 +10,6 @@ jest.mock('next/navigation', () => ({
 
 jest.mock("js-cookie", () => ({
   get: jest.fn(),
-}));
-
-jest.mock("@/lib/utils", () => ({
-  ...jest.requireActual("@/lib/utils"),
-  decodeToken: jest.fn(),
 }));
 
 describe('CalibrationRequestCreatePage', () => {
@@ -30,10 +24,9 @@ describe('CalibrationRequestCreatePage', () => {
     (useRouter as jest.Mock).mockReturnValue({ push: mockPush, back: mockBack });
     (useParams as jest.Mock).mockImplementation(mockUseParams);
     (Cookies.get as jest.Mock).mockReturnValue("mock-token");
-    (decodeToken as jest.Mock).mockReturnValue({ userId: 'mock-user-id' });
 
     global.fetch = jest.fn().mockImplementation((url) => {
-      if (url === `${process.env.NEXT_PUBLIC_API_URL}/calibration-request`) {
+      if (url === `${process.env.NEXT_PUBLIC_API_URL}/request/calibration`) {
         return Promise.resolve({
           ok: true,
           json: () => Promise.resolve({}),
@@ -137,7 +130,7 @@ describe('CalibrationRequestCreatePage', () => {
   
   it('should open the error modal when there is an error and closed when get clicked', async () => {
     global.fetch = jest.fn().mockImplementation((url) => {
-      if (url === `${process.env.NEXT_PUBLIC_API_URL}/calibration-request`) {
+      if (url === `${process.env.NEXT_PUBLIC_API_URL}/request/calibration`) {
         return Promise.resolve({
           ok: false,
           json: () => Promise.resolve({}),
@@ -194,7 +187,7 @@ describe('CalibrationRequestCreatePage', () => {
 
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith(
-        `${process.env.NEXT_PUBLIC_API_URL}/calibration-request`,
+        `${process.env.NEXT_PUBLIC_API_URL}/request/calibration`,
         expect.objectContaining({
           method: 'POST',
           headers: {

--- a/__tests__/app/dashboard/medical-equipment/[id]/maintenance-request/page.unit.test.tsx
+++ b/__tests__/app/dashboard/medical-equipment/[id]/maintenance-request/page.unit.test.tsx
@@ -1,10 +1,20 @@
 import { render, screen } from '@testing-library/react';
-import MaintenanceRequestCreatePage from '@/app/dashboard/medical-equipment/[id]/maintenance-request/page';
+import MaintenanceRequestCreate from '@/modules/medical-equipment/request/maintenance/maintenance-request-create';
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+  useParams: jest.fn().mockReturnValue({ id: 'dummy-id' }),
+}));
 
 describe('MaintenanceRequestCreatePage', () => {
-  it('', () => {
-    render(<MaintenanceRequestCreatePage />);
-    const pageName = screen.getByText('MaintenanceRequestCreate');
-    expect(pageName).toBeInTheDocument();
+  it('renders the page correctly', () => {
+    render(<MaintenanceRequestCreate />);
+    
+    expect(screen.getByText('Kembali')).toBeInTheDocument();
+    expect(screen.getByText('Minta Maintenance')).toBeInTheDocument();
+    expect(screen.getByLabelText(/Alat/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Catatan/i)).toBeInTheDocument();
+    expect(screen.getByText('Batalkan')).toBeInTheDocument();
+    expect(screen.getByText('Simpan')).toBeInTheDocument();
   });
 });

--- a/__tests__/app/dashboard/medical-equipment/[id]/maintenance-request/page.unit.test.tsx
+++ b/__tests__/app/dashboard/medical-equipment/[id]/maintenance-request/page.unit.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import MaintenanceRequestCreate from '@/modules/medical-equipment/request/maintenance/maintenance-request-create';
+import { useRouter } from 'next/navigation';
 
 jest.mock('next/navigation', () => ({
   useRouter: jest.fn(),
@@ -7,6 +8,13 @@ jest.mock('next/navigation', () => ({
 }));
 
 describe('MaintenanceRequestCreatePage', () => {
+  let mockBack: jest.Mock;
+
+  beforeEach(() => {
+    mockBack = jest.fn();
+    (useRouter as jest.Mock).mockReturnValue({ back: mockBack });
+  });
+
   it('renders the page correctly', () => {
     render(<MaintenanceRequestCreate />);
     
@@ -16,5 +24,23 @@ describe('MaintenanceRequestCreatePage', () => {
     expect(screen.getByLabelText(/Catatan/i)).toBeInTheDocument();
     expect(screen.getByText('Batalkan')).toBeInTheDocument();
     expect(screen.getByText('Simpan')).toBeInTheDocument();
+  });
+
+  it('should go back when the kembali button is clicked', () => {
+    render(<MaintenanceRequestCreate />);
+    
+    const backButton = screen.getByText('Kembali');
+    backButton.click();
+    
+    expect(mockBack).toHaveBeenCalled();
+  });
+
+  it('should go back when the batalkan button is clicked', () => {
+    render(<MaintenanceRequestCreate />);
+    
+    const cancelButton = screen.getByText('Batalkan');
+    cancelButton.click();
+    
+    expect(mockBack).toHaveBeenCalled();
   });
 });

--- a/__tests__/app/dashboard/medical-equipment/[id]/maintenance-request/page.unit.test.tsx
+++ b/__tests__/app/dashboard/medical-equipment/[id]/maintenance-request/page.unit.test.tsx
@@ -2,7 +2,6 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import MaintenanceRequestCreate from '@/modules/medical-equipment/request/maintenance/maintenance-request-create';
 import { useRouter, useParams } from 'next/navigation';
 import Cookies from "js-cookie";
-import { decodeToken } from "@/lib/utils";
 
 jest.mock('next/navigation', () => ({
   useRouter: jest.fn(),
@@ -11,11 +10,6 @@ jest.mock('next/navigation', () => ({
 
 jest.mock("js-cookie", () => ({
   get: jest.fn(),
-}));
-
-jest.mock("@/lib/utils", () => ({
-  ...jest.requireActual("@/lib/utils"),
-  decodeToken: jest.fn(),
 }));
 
 describe('MaintenanceRequestCreatePage', () => {
@@ -30,10 +24,9 @@ describe('MaintenanceRequestCreatePage', () => {
     (useRouter as jest.Mock).mockReturnValue({ push: mockPush, back: mockBack });
     (useParams as jest.Mock).mockImplementation(mockUseParams);
     (Cookies.get as jest.Mock).mockReturnValue("mock-token");
-    (decodeToken as jest.Mock).mockReturnValue({ userId: 'mock-user-id' });
 
     global.fetch = jest.fn().mockImplementation((url) => {
-      if (url === `${process.env.NEXT_PUBLIC_API_URL}/maintenance-request`) {
+      if (url === `${process.env.NEXT_PUBLIC_API_URL}/request/maintenance`) {
         return Promise.resolve({
           ok: true,
           json: () => Promise.resolve({}),
@@ -137,7 +130,7 @@ describe('MaintenanceRequestCreatePage', () => {
   
   it('should open the error modal when there is an error and closed when get clicked', async () => {
     global.fetch = jest.fn().mockImplementation((url) => {
-      if (url === `${process.env.NEXT_PUBLIC_API_URL}/maintenance-request`) {
+      if (url === `${process.env.NEXT_PUBLIC_API_URL}/request/maintenance`) {
         return Promise.resolve({
           ok: false,
           json: () => Promise.resolve({}),
@@ -194,7 +187,7 @@ describe('MaintenanceRequestCreatePage', () => {
 
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith(
-        `${process.env.NEXT_PUBLIC_API_URL}/maintenance-request`,
+        `${process.env.NEXT_PUBLIC_API_URL}/request/maintenance`,
         expect.objectContaining({
           method: 'POST',
           headers: {

--- a/__tests__/app/dashboard/medical-equipment/[id]/maintenance-request/page.unit.test.tsx
+++ b/__tests__/app/dashboard/medical-equipment/[id]/maintenance-request/page.unit.test.tsx
@@ -1,21 +1,62 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { act } from 'react';
 import MaintenanceRequestCreate from '@/modules/medical-equipment/request/maintenance/maintenance-request-create';
-import { useRouter } from 'next/navigation';
+import { useRouter, useParams } from 'next/navigation';
+import Cookies from "js-cookie";
+import { decodeToken } from "@/lib/utils";
 
 jest.mock('next/navigation', () => ({
   useRouter: jest.fn(),
-  useParams: jest.fn().mockReturnValue({ id: 'dummy-id' }),
+  useParams: jest.fn(),
+}));
+
+jest.mock("js-cookie", () => ({
+  get: jest.fn(),
+}));
+
+jest.mock("@/lib/utils", () => ({
+  ...jest.requireActual("@/lib/utils"),
+  decodeToken: jest.fn(),
 }));
 
 describe('MaintenanceRequestCreatePage', () => {
+  let mockPush: jest.Mock;
   let mockBack: jest.Mock;
+  let mockUseParams: jest.Mock;
 
   beforeEach(() => {
     mockBack = jest.fn();
-    (useRouter as jest.Mock).mockReturnValue({ back: mockBack });
+    mockPush = jest.fn();
+    mockUseParams = jest.fn().mockReturnValue({ id: "1" });
+    (useRouter as jest.Mock).mockReturnValue({ push: mockPush, back: mockBack });
+    (useParams as jest.Mock).mockImplementation(mockUseParams);
+    (Cookies.get as jest.Mock).mockReturnValue("mock-token");
+    (decodeToken as jest.Mock).mockReturnValue({ userId: 'mock-user-id' });
+
+    global.fetch = jest.fn().mockImplementation((url) => {
+      if (url === `${process.env.NEXT_PUBLIC_API_URL}/maintenance-request`) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({}),
+        });
+      } else if (url === `${process.env.NEXT_PUBLIC_API_URL}/medical-equipment/1`) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ name: "mock-equipment-name" }),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        json: () => Promise.resolve({}),
+      });
+    });
   });
 
-  it('renders the page correctly', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the page correctly', async () => {
     render(<MaintenanceRequestCreate />);
     
     expect(screen.getByText('Kembali')).toBeInTheDocument();
@@ -23,7 +64,10 @@ describe('MaintenanceRequestCreatePage', () => {
     expect(screen.getByLabelText(/Alat/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/Catatan/i)).toBeInTheDocument();
     expect(screen.getByText('Batalkan')).toBeInTheDocument();
-    expect(screen.getByText('Simpan')).toBeInTheDocument();
+    expect(screen.getByText('Menyimpan...')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('Simpan')).toBeInTheDocument();
+    });
   });
 
   it('should go back when the kembali button is clicked', () => {
@@ -42,5 +86,128 @@ describe('MaintenanceRequestCreatePage', () => {
     cancelButton.click();
     
     expect(mockBack).toHaveBeenCalled();
+  });
+  
+  it('should handle missing token', async () => {
+    (Cookies.get as jest.Mock).mockReturnValueOnce(null);
+    console.error = jest.fn();
+
+    render(<MaintenanceRequestCreate />);
+
+    await waitFor(() => {
+      expect(console.error).toHaveBeenCalled();
+    });
+  });
+
+  it('should call the API to fetch medical equipment name', async () => {
+    render(<MaintenanceRequestCreate />);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${process.env.NEXT_PUBLIC_API_URL}/medical-equipment/1`,
+        expect.objectContaining({
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': expect.stringContaining('Bearer'),
+          },
+        })
+      );
+    });
+  });
+  
+  it('should handle error when fetching medical equipment name fails', async () => {
+    global.fetch = jest.fn().mockImplementationOnce((url) => 
+      url === `${process.env.NEXT_PUBLIC_API_URL}/medical-equipment/1` 
+        ? Promise.resolve({
+            ok: false,
+            json: () => Promise.resolve({}),
+          })
+        : Promise.resolve()
+    );
+    console.error = jest.fn();
+
+    render(<MaintenanceRequestCreate />);
+
+    await waitFor(() => {
+      expect(console.error).toHaveBeenCalledWith(
+        'Error fetching medical equipment name:', 
+        expect.any(Error));
+    });
+  });
+  
+  it('should open the error modal when there is an error and closed when get clicked', async () => {
+    global.fetch = jest.fn().mockImplementation((url) => {
+      if (url === `${process.env.NEXT_PUBLIC_API_URL}/maintenance-request`) {
+        return Promise.resolve({
+          ok: false,
+          json: () => Promise.resolve({}),
+        });
+      } else if (url === `${process.env.NEXT_PUBLIC_API_URL}/medical-equipment/1`) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ name: "mock-equipment-name" }),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        json: () => Promise.resolve({}),
+      });
+    });
+
+    render(<MaintenanceRequestCreate />);
+
+    await waitFor(() => {
+      fireEvent.change(screen.getByLabelText(/Catatan/i), {
+        target: { value: 'Test complaint' }
+      });
+      fireEvent.click(screen.getByText('Simpan'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Failed to create maintenance request')).toHaveLength(2);
+    });
+
+    fireEvent.click(screen.getByText('Close'));
+
+    await waitFor(() => {
+      const errorTexts = screen.getAllByText('Failed to create maintenance request');
+      expect(errorTexts).toHaveLength(1);
+    });
+  });
+  
+  it('should submit the form successfully', async () => {
+    render(<MaintenanceRequestCreate />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Catatan/i)).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText(/Catatan/i), {
+      target: { value: 'Valid complaint' }
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Simpan')).toBeInTheDocument();
+    });
+    
+    fireEvent.click(screen.getByText('Simpan'));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${process.env.NEXT_PUBLIC_API_URL}/maintenance-request`,
+        expect.objectContaining({
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': expect.stringContaining('Bearer'),
+          },
+          body: expect.any(String)
+        })
+      );
+      expect(mockPush).toHaveBeenCalledWith(
+        '/dashboard/medical-equipment/1?success=true'
+      );
+    });
   });
 });

--- a/__tests__/app/dashboard/medical-equipment/[id]/maintenance-request/page.unit.test.tsx
+++ b/__tests__/app/dashboard/medical-equipment/[id]/maintenance-request/page.unit.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { act } from 'react';
 import MaintenanceRequestCreate from '@/modules/medical-equipment/request/maintenance/maintenance-request-create';
 import { useRouter, useParams } from 'next/navigation';
 import Cookies from "js-cookie";
@@ -42,7 +41,7 @@ describe('MaintenanceRequestCreatePage', () => {
       } else if (url === `${process.env.NEXT_PUBLIC_API_URL}/medical-equipment/1`) {
         return Promise.resolve({
           ok: true,
-          json: () => Promise.resolve({ name: "mock-equipment-name" }),
+          json: () => Promise.resolve({ data: { name: "mock-equipment-name" } }),
         });
       }
       return Promise.resolve({
@@ -146,7 +145,7 @@ describe('MaintenanceRequestCreatePage', () => {
       } else if (url === `${process.env.NEXT_PUBLIC_API_URL}/medical-equipment/1`) {
         return Promise.resolve({
           ok: true,
-          json: () => Promise.resolve({ name: "mock-equipment-name" }),
+          json: () => Promise.resolve({ data: { name: "mock-equipment-name" } }),
         });
       }
       return Promise.resolve({

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Textarea = React.forwardRef<
+  HTMLTextAreaElement,
+  React.ComponentProps<"textarea">
+>(({ className, ...props }, ref) => {
+  return (
+    <textarea
+      className={cn(
+        "flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  )
+})
+Textarea.displayName = "Textarea"
+
+export { Textarea }

--- a/src/modules/medical-equipment/request/calibration/calibration-request-create.tsx
+++ b/src/modules/medical-equipment/request/calibration/calibration-request-create.tsx
@@ -10,15 +10,12 @@ import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "
 import { Textarea } from "@/components/ui/textarea"
 import { ArrowLeft } from "lucide-react"
 import { useRouter, useParams } from "next/navigation"
-import { decodeToken } from "@/lib/utils"
 import Cookies from "js-cookie"
 
 const formSchema = z.object({
   medicalEquipment: z.string().min(1),
   complaint: z.string().optional(),
-  userId: z.string().min(1),
   submissionDate: z.string(),
-  createdBy: z.string().min(1),
 });
 
 export default function CalibrationRequestCreate() {
@@ -34,9 +31,7 @@ export default function CalibrationRequestCreate() {
     defaultValues: {
       medicalEquipment: "",
       complaint: "",
-      userId: "",
       submissionDate: "",
-      createdBy: "",
     },
   });
 
@@ -46,21 +41,6 @@ export default function CalibrationRequestCreate() {
     if (!token) throw new Error("No token found");
     return token;
   }
-
-  const fetchUserId = async () => {
-    setLoading(true);
-    try {
-      const token = await getToken();
-  
-      const decodedToken = decodeToken(token);
-      form.setValue("userId", decodedToken.userId);
-      form.setValue("createdBy", decodedToken.userId);
-    } catch (error) {
-      console.error("Error fetching user data:", error);
-    } finally {
-      setLoading(false);
-    }
-  };
 
   const fetchMedicalEquipmentName = async () => {
     setLoading(true);
@@ -92,7 +72,7 @@ export default function CalibrationRequestCreate() {
     try {
       const token = await getToken();
 
-      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/calibration-request`, {
+      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/request/calibration`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -130,7 +110,6 @@ export default function CalibrationRequestCreate() {
   };
 
   useEffect(() => {
-    fetchUserId();
     fetchMedicalEquipmentName();
   }, [equipmentId]);
 

--- a/src/modules/medical-equipment/request/calibration/calibration-request-create.tsx
+++ b/src/modules/medical-equipment/request/calibration/calibration-request-create.tsx
@@ -1,6 +1,210 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { z } from "zod"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
+import { Textarea } from "@/components/ui/textarea"
+import { ArrowLeft } from "lucide-react"
+import { useRouter, useParams } from "next/navigation"
+import { decodeToken } from "@/lib/utils"
+import Cookies from "js-cookie"
+
+const formSchema = z.object({
+  medicalEquipment: z.string().min(1),
+  complaint: z.string().optional(),
+  userId: z.string().min(1),
+  submissionDate: z.string(),
+  createdBy: z.string().min(1),
+});
 
 export default function CalibrationRequestCreate() {
-    return (
-        <div>CalibrationRequestCreate</div>
-    );
+  const router = useRouter()
+  const params = useParams()
+  const equipmentId = params.id as string
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [errorModalOpen, setErrorModalOpen] = useState(false)
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      medicalEquipment: "",
+      complaint: "",
+      userId: "",
+      submissionDate: "",
+      createdBy: "",
+    },
+  });
+
+  const getToken = async () => {
+    const token = Cookies.get("token");
+
+    if (!token) throw new Error("No token found");
+    return token;
   }
+
+  const fetchUserId = async () => {
+    setLoading(true);
+    try {
+      const token = await getToken();
+  
+      const decodedToken = decodeToken(token);
+      form.setValue("userId", decodedToken.userId);
+      form.setValue("createdBy", decodedToken.userId);
+    } catch (error) {
+      console.error("Error fetching user data:", error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const fetchMedicalEquipmentName = async () => {
+    setLoading(true);
+    try {
+      const token = await getToken();
+
+      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/medical-equipment/${equipmentId}`, {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error("Failed to fetch medical equipment name");
+      }
+
+      const data = await response.json();
+      form.setValue("medicalEquipment", data.data.name);
+    } catch (error) {
+      console.error("Error fetching medical equipment name:", error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const createCalibrationRequest = async (data: z.infer<typeof formSchema>) => {
+    try {
+      const token = await getToken();
+
+      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/calibration-request`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(data),
+      });
+
+      if (!response.ok) {
+        throw new Error("Failed to create calibration request");
+      }
+
+      const result = await response.json();
+      return result;
+    } catch (error) {
+      console.error("Error creating calibration request:", error);
+      throw(error);
+    }
+  };
+
+  const onsubmit = async (data: z.infer<typeof formSchema>) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const submissionDate = new Date().toISOString();
+      await createCalibrationRequest({...data, submissionDate});
+      router.push(`/dashboard/medical-equipment/${equipmentId}?success=true`);
+    } catch (error) {
+      setError("Failed to create calibration request");
+      setErrorModalOpen(true);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchUserId();
+    fetchMedicalEquipmentName();
+  }, [equipmentId]);
+
+  return (
+    <>
+      <div className="flex flex-col items-start gap-4">
+        <Button variant="outline" onClick={() => router.back()} className="mr-4">
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Kembali
+        </Button>
+        <span className="text-header-h5 font-bold font-poppins">Minta Calibration</span>
+      </div>
+
+      {error && <div className="text-red-500 mt-2">{error}</div>}
+      {errorModalOpen && (
+        <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4">
+          <span className="block sm:inline">{error}</span>
+          <span className="absolute top-0 bottom-0 right-0 px-4 py-3" onClick={() => setErrorModalOpen(false)}>
+            <svg
+              className="fill-current h-6 w-6 text-red-500"
+              role="button"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+            >
+              <title>Close</title>
+              <path d="M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 3.029a1.2 1.2 0 1 1-1.697-1.697l2.758-3.15-2.759-3.152a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-3.031a1.2 1.2 0 1 1 1.697 1.697l-2.758 3.152 2.758 3.15a1.2 1.2 0 0 1 0 1.698z" />
+            </svg>
+          </span>
+        </div>
+      )}
+
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onsubmit)} className="space-y-6 mt-4">
+          <FormField
+            control={form.control}
+            name="medicalEquipment"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Alat</FormLabel>
+                <FormControl>
+                    <Input disabled placeholder="Loading..." {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="complaint"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Catatan</FormLabel>
+                <FormControl>
+                  <Textarea
+                    placeholder="Masukkan keluhan"
+                    className="min-h-[100px]"
+                    {...field}
+                  />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+
+          <div className="flex justify-end space-x-4">
+            <Button type="button" variant="destructive" onClick={() => router.back()}>
+              Batalkan
+            </Button>
+            <Button type="submit" disabled={loading}>
+              {loading ? "Menyimpan..." : "Simpan"}
+            </Button>
+          </div>
+        </form>
+      </Form>
+    </>
+  )
+}

--- a/src/modules/medical-equipment/request/maintenance/maintenance-request-create.tsx
+++ b/src/modules/medical-equipment/request/maintenance/maintenance-request-create.tsx
@@ -32,7 +32,7 @@ export default function MaintenanceRequestCreate() {
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      medicalEquipment: "Loading...",
+      medicalEquipment: "",
       complaint: "",
       userId: "",
       submissionDate: "",
@@ -171,7 +171,7 @@ export default function MaintenanceRequestCreate() {
               <FormItem>
                 <FormLabel>Alat</FormLabel>
                 <FormControl>
-                    <Input disabled {...field} />
+                    <Input disabled placeholder="Loading..." {...field} />
                 </FormControl>
                 <FormMessage />
               </FormItem>

--- a/src/modules/medical-equipment/request/maintenance/maintenance-request-create.tsx
+++ b/src/modules/medical-equipment/request/maintenance/maintenance-request-create.tsx
@@ -1,6 +1,120 @@
+"use client"
+
+import { useState } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { z } from "zod"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Form, FormControl, FormField, FormItem, FormLabel } from "@/components/ui/form"
+import { ArrowLeft } from "lucide-react"
+import { useRouter, useParams } from "next/navigation"
+
+const formSchema = z.object({
+  userId: z.string().min(1),
+  medicalEquipment: z.string().min(1),
+  complaint: z.string().optional(),
+  submissionDate: z.date(),
+  createdBy: z.string().min(1),
+});
 
 export default function MaintenanceRequestCreate() {
-    return (
-        <div>MaintenanceRequestCreate</div>
-    );
-  }
+  const router = useRouter()
+  const params = useParams()
+  const equipmentId = params.id as string
+
+  const userId = localStorage.getItem("userId") || "";
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+      defaultValues: {
+      userId: userId,
+      medicalEquipment: equipmentId,
+      complaint: "",
+      submissionDate: new Date(),
+      createdBy: userId,
+    },
+  });
+
+  const onsubmit = async (values: z.infer<typeof formSchema>) => {
+
+  };
+
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [errorMessage, setErrorMessage] = useState("")
+  const [errorModalOpen, setErrorModalOpen] = useState(false)
+
+  return (
+    <>
+      <div className="flex flex-col items-start gap-4">
+        <Button variant="outline" onClick={() => router.back()} className="mr-4">
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Kembali
+        </Button>
+        <span className="text-header-h5 font-bold font-poppins">Minta Maintenance</span>
+      </div>
+
+      {error && <div className="text-red-500 mt-2">{error}</div>}
+      {errorModalOpen && (
+        <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4">
+          <span className="block sm:inline">{errorMessage}</span>
+          <span className="absolute top-0 bottom-0 right-0 px-4 py-3" onClick={() => setErrorModalOpen(false)}>
+            <svg
+              className="fill-current h-6 w-6 text-red-500"
+              role="button"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+            >
+              <title>Close</title>
+              <path d="M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 3.029a1.2 1.2 0 1 1-1.697-1.697l2.758-3.15-2.759-3.152a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-3.031a1.2 1.2 0 1 1 1.697 1.697l-2.758 3.152 2.758 3.15a1.2 1.2 0 0 1 0 1.698z" />
+            </svg>
+          </span>
+        </div>
+      )}
+
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onsubmit)} className="space-y-6 mt-4">
+          <FormField
+            control={form.control}
+            name="medicalEquipment"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Alat</FormLabel>
+                <FormControl>
+                    <Input disabled {...field} />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="complaint"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Catatan</FormLabel>
+                <FormControl>
+                  <Input placeholder="Masukkan keluhan" {...field} />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+
+          <input type="hidden" {...form.register("userId")} />
+          <input type="hidden" {...form.register("submissionDate")} />
+          <input type="hidden" {...form.register("createdBy")} />
+
+          <div className="flex justify-end space-x-4">
+            <Button type="button" variant="destructive" onClick={() => router.back()}>
+              Batalkan
+            </Button>
+            <Button type="submit" disabled={loading}>
+              {loading ? "Menyimpan..." : "Simpan"}
+            </Button>
+          </div>
+        </form>
+      </Form>
+    </>
+  )
+}

--- a/src/modules/medical-equipment/request/maintenance/maintenance-request-create.tsx
+++ b/src/modules/medical-equipment/request/maintenance/maintenance-request-create.tsx
@@ -1,20 +1,23 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { z } from "zod"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { Form, FormControl, FormField, FormItem, FormLabel } from "@/components/ui/form"
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
+import { Textarea } from "@/components/ui/textarea"
 import { ArrowLeft } from "lucide-react"
 import { useRouter, useParams } from "next/navigation"
+import { decodeToken } from "@/lib/utils"
+import Cookies from "js-cookie"
 
 const formSchema = z.object({
-  userId: z.string().min(1),
   medicalEquipment: z.string().min(1),
   complaint: z.string().optional(),
-  submissionDate: z.date(),
+  userId: z.string().min(1),
+  submissionDate: z.string(),
   createdBy: z.string().min(1),
 });
 
@@ -22,28 +25,114 @@ export default function MaintenanceRequestCreate() {
   const router = useRouter()
   const params = useParams()
   const equipmentId = params.id as string
-
-  const userId = localStorage.getItem("userId") || "";
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [errorModalOpen, setErrorModalOpen] = useState(false)
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
-      defaultValues: {
-      userId: userId,
-      medicalEquipment: equipmentId,
+    defaultValues: {
+      medicalEquipment: "Loading...",
       complaint: "",
-      submissionDate: new Date(),
-      createdBy: userId,
+      userId: "",
+      submissionDate: "",
+      createdBy: "",
     },
   });
 
-  const onsubmit = async (values: z.infer<typeof formSchema>) => {
+  const getToken = async () => {
+    const token = Cookies.get("token");
 
+    if (!token) throw new Error("No token found");
+    return token;
+  }
+
+  const fetchUserId = async () => {
+    setLoading(true);
+    try {
+      const token = await getToken();
+  
+      const decodedToken = decodeToken(token);
+      form.setValue("userId", decodedToken.userId);
+      form.setValue("createdBy", decodedToken.userId);
+    } catch (error) {
+      console.error("Error fetching user data:", error);
+    } finally {
+      setLoading(false);
+    }
   };
 
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const [errorMessage, setErrorMessage] = useState("")
-  const [errorModalOpen, setErrorModalOpen] = useState(false)
+  const fetchMedicalEquipmentName = async () => {
+    setLoading(true);
+    try {
+      const token = await getToken();
+
+      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/medical-equipment/${equipmentId}`, {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error("Failed to fetch medical equipment name");
+      }
+
+      const data = await response.json();
+      form.setValue("medicalEquipment", data.data.name);
+    } catch (error) {
+      console.error("Error fetching medical equipment name:", error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const createMaintenanceRequest = async (data: z.infer<typeof formSchema>) => {
+    try {
+      const token = await getToken();
+
+      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/maintenance-request`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(data),
+      });
+
+      if (!response.ok) {
+        throw new Error("Failed to create maintenance request");
+      }
+
+      const result = await response.json();
+      return result;
+    } catch (error) {
+      console.error("Error creating maintenance request:", error);
+      throw(error);
+    }
+  };
+
+  const onsubmit = async (data: z.infer<typeof formSchema>) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const submissionDate = new Date().toISOString();
+      await createMaintenanceRequest({...data, submissionDate});
+      router.push(`/dashboard/medical-equipment/${equipmentId}?success=true`);
+    } catch (error) {
+      setError("Failed to create maintenance request");
+      setErrorModalOpen(true);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchUserId();
+    fetchMedicalEquipmentName();
+  }, [equipmentId]);
 
   return (
     <>
@@ -58,7 +147,7 @@ export default function MaintenanceRequestCreate() {
       {error && <div className="text-red-500 mt-2">{error}</div>}
       {errorModalOpen && (
         <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4">
-          <span className="block sm:inline">{errorMessage}</span>
+          <span className="block sm:inline">{error}</span>
           <span className="absolute top-0 bottom-0 right-0 px-4 py-3" onClick={() => setErrorModalOpen(false)}>
             <svg
               className="fill-current h-6 w-6 text-red-500"
@@ -84,6 +173,7 @@ export default function MaintenanceRequestCreate() {
                 <FormControl>
                     <Input disabled {...field} />
                 </FormControl>
+                <FormMessage />
               </FormItem>
             )}
           />
@@ -95,15 +185,15 @@ export default function MaintenanceRequestCreate() {
               <FormItem>
                 <FormLabel>Catatan</FormLabel>
                 <FormControl>
-                  <Input placeholder="Masukkan keluhan" {...field} />
+                  <Textarea
+                    placeholder="Masukkan keluhan"
+                    className="min-h-[100px]"
+                    {...field}
+                  />
                 </FormControl>
               </FormItem>
             )}
           />
-
-          <input type="hidden" {...form.register("userId")} />
-          <input type="hidden" {...form.register("submissionDate")} />
-          <input type="hidden" {...form.register("createdBy")} />
 
           <div className="flex justify-end space-x-4">
             <Button type="button" variant="destructive" onClick={() => router.back()}>

--- a/src/modules/medical-equipment/request/maintenance/maintenance-request-create.tsx
+++ b/src/modules/medical-equipment/request/maintenance/maintenance-request-create.tsx
@@ -10,15 +10,12 @@ import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "
 import { Textarea } from "@/components/ui/textarea"
 import { ArrowLeft } from "lucide-react"
 import { useRouter, useParams } from "next/navigation"
-import { decodeToken } from "@/lib/utils"
 import Cookies from "js-cookie"
 
 const formSchema = z.object({
   medicalEquipment: z.string().min(1),
   complaint: z.string().optional(),
-  userId: z.string().min(1),
   submissionDate: z.string(),
-  createdBy: z.string().min(1),
 });
 
 export default function MaintenanceRequestCreate() {
@@ -34,9 +31,7 @@ export default function MaintenanceRequestCreate() {
     defaultValues: {
       medicalEquipment: "",
       complaint: "",
-      userId: "",
       submissionDate: "",
-      createdBy: "",
     },
   });
 
@@ -46,21 +41,6 @@ export default function MaintenanceRequestCreate() {
     if (!token) throw new Error("No token found");
     return token;
   }
-
-  const fetchUserId = async () => {
-    setLoading(true);
-    try {
-      const token = await getToken();
-  
-      const decodedToken = decodeToken(token);
-      form.setValue("userId", decodedToken.userId);
-      form.setValue("createdBy", decodedToken.userId);
-    } catch (error) {
-      console.error("Error fetching user data:", error);
-    } finally {
-      setLoading(false);
-    }
-  };
 
   const fetchMedicalEquipmentName = async () => {
     setLoading(true);
@@ -92,7 +72,7 @@ export default function MaintenanceRequestCreate() {
     try {
       const token = await getToken();
 
-      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/maintenance-request`, {
+      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/request/maintenance`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -130,7 +110,6 @@ export default function MaintenanceRequestCreate() {
   };
 
   useEffect(() => {
-    fetchUserId();
     fetchMedicalEquipmentName();
   }, [equipmentId]);
 


### PR DESCRIPTION
# Add Maintenance and Calibration Requests
Closes  #42

## Summary
- Implemented maintenance and calibration request pages, allow users to create maintenance or calibration request for medical equipments
- Integrated with backend API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a fully functional calibration request form for medical equipment, including form validation, API integration, error handling, and user feedback.
	- Added a complete maintenance request form with similar capabilities, such as validation, authenticated API calls, error modals, and navigation.
	- Added a reusable, styled textarea component for consistent form input.

- **Tests**
	- Rewrote and expanded unit tests for both calibration and maintenance request forms, covering rendering, user interactions, API responses, navigation, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->